### PR TITLE
Use bundled File instead of pathwatcher

### DIFF
--- a/lib/rst-preview-view.coffee
+++ b/lib/rst-preview-view.coffee
@@ -1,9 +1,8 @@
 path = require 'path'
-{Emitter, Disposable, CompositeDisposable} = require 'atom'
+{Emitter, Disposable, CompositeDisposable, File} = require 'atom'
 {$, $$$, ScrollView} = require 'atom-space-pen-views'
 Grim = require 'grim'
 _ = require 'underscore-plus'
-{File} = require 'pathwatcher'
 fs = require 'fs-plus'
 {extensionForFenceName} = require './extension-helper'
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "fs-plus": "^2.0.0",
     "grim": "^1.2.0",
     "highlights": "^1.0.0",
-    "pathwatcher": "^4.3",
     "roaster": "^1.1.2",
     "temp": "^0.8.1",
     "underscore-plus": "^1.0.0",


### PR DESCRIPTION
Using the bundled File instead of pathwatcher avoids some compilation error on OS X 10.11 and Atom 1.2.1
