### PR TITLE
Replace Q.done with Promise.then

### DIFF
--- a/lib/rst-preview.coffee
+++ b/lib/rst-preview.coffee
@@ -93,7 +93,7 @@ module.exports =
   addPreviewForEditor: (editor) ->
     uri = @uriForEditor(editor)
     previousActivePane = atom.workspace.getActivePane()
-    atom.workspace.open(uri, split: 'right', searchAllPanes: true).done (rstPreviewView) ->
+    atom.workspace.open(uri, split: 'right', searchAllPanes: true).then (rstPreviewView) ->
       if isRstPreviewView(rstPreviewView)
         previousActivePane.activate()
 


### PR DESCRIPTION
This commit fixes #45 (Atom now uses ES6 Promises instead of Q. Call promise.then instead of promise.done)